### PR TITLE
fix: namespace script, executable, and tmp dir

### DIFF
--- a/lib/action.bash
+++ b/lib/action.bash
@@ -7,10 +7,11 @@ set -u
 declare VAR_PREFIX=BUILDKITE_PLUGIN_BOOST_SECURITY_SCANNER
 
 export BOOST_TMP_DIR=${BOOST_TMP_DIR:-${WORKSPACE_TMP:-${TMPDIR:-/tmp}}}
-export BOOST_BIN=${BOOST_BIN:-${BOOST_TMP_DIR}/boost.sh}
-export BOOST_CLI=${BOOST_CLI:-${BOOST_TMP_DIR}/boost-cli}
+export BOOST_TMP_DIR_FOR_STEP=${BOOST_TMP_DIR}/${BUILDKITE_STEP_ID}
+export BOOST_BIN=${BOOST_BIN:-${BOOST_TMP_DIR_FOR_STEP}/boost.sh}
+export BOOST_CLI=${BOOST_CLI:-${BOOST_TMP_DIR_FOR_STEP}/boost-cli}
 export BOOST_EXE=${BOOST_EXE:-${BOOST_CLI}/boost.dist/boost}
-export BOOST_ENV=${BOOST_ENV:-${BOOST_TMP_DIR}/boost.env}
+export BOOST_ENV=${BOOST_ENV:-${BOOST_TMP_DIR_FOR_STEP}/boost.env}
 
 config.get ()
 { # $1=key, [$2=default]
@@ -62,7 +63,7 @@ init.config ()
 init.cli ()
 {
   log.info "installing cli to ${BOOST_BIN}"
-  mkdir -p "${BOOST_TMP_DIR}"
+  mkdir -p "${BOOST_TMP_DIR_FOR_STEP}"
   curl --silent --output "${BOOST_BIN}" "${BOOST_CLI_URL}"
   chmod 755 "${BOOST_BIN}"
 


### PR DESCRIPTION
A single Buildkite node may run multiple agents, each of which may
run multiple steps (from different pipelines). Namespace all temp
files created by boost with the running buildkite step's uuid in order
to remove conflicts from concurrent steps.

This should resolve an issue where the CLI sometimes fails to install
(likely because a concurrent step is using the file already).

```log
[INFO] installing cli to /tmp/boost.sh
/var/lib/buildkite-agent/plugins/github-com-peaudecastor-boost-security-scanner-buildkite-plugin-v2-0/hooks/../lib/action.bash: /tmp/boost.sh: /bin/sh: bad interpreter: Text file busy
```

In the future, it would be nice to configure the plugin to install
the CLI only if it does not exist or if the existing one is an old
version (and not remove the cli after running the step). This would
speed up most builds, but would likely require a new
api.boostsecurity.io endpoint which provides the latest CLI version.