### PR TITLE
Atomic installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased - [Github](https://github.com/peaudecastor/boost-security-scanner-buildkite-plugin/compare/v2.0.5..HEAD)
 
+- migrate downloader to get-boost-cli
+- migrate cli installation path to tmp\_dir/boost/cli/<version>
+
 ## 2.0.5 - 2021-06-22 - [Github](https://github.com/peaudecastor/boost-security-scanner-github/compare/2.0.4..2.0.5)
 
 - add `exec_full_repo` to require a full repo and not delete unmodified files on diff scans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased - [Github](https://github.com/peaudecastor/boost-security-scanner-buildkite-plugin/compare/v2.0.5..HEAD)
+## Unreleased - [Github](https://github.com/peaudecastor/boost-security-scanner-buildkite-plugin/compare/v2.0.6..HEAD)
+
+## 2.0.6 - 2021-08-30 - [Github](https://github.com/peaudecastor/boost-security-scanner-github/compare/2.0.5..2.0.6)
 
 - migrate downloader to get-boost-cli
 - migrate cli installation path to tmp\_dir/boost/cli/<version>


### PR DESCRIPTION
Updates the installer to use get-boost-cli.

Notable changes : 
- download files to `%TMPDIR%/boost/cli/<version>` while preserving previous symlinks
- verify etag of rolling releases to download conditionally
- fixes a bug displaying time ( was months not minutes )

Resolve issue reported in https://github.com/peaudecastor/boost-security-scanner-buildkite-plugin/pull/3
